### PR TITLE
Support empty list of action's allowed_on_statuses

### DIFF
--- a/src/pages/main/env/deployments/page/DeploymentActions.vue
+++ b/src/pages/main/env/deployments/page/DeploymentActions.vue
@@ -200,9 +200,10 @@ export default defineComponent({
             currentStatus.value
                 ? actions.value.filter((action) =>
                       action.allowed_on_statuses
-                          ? action.allowed_on_statuses.indexOf(
+                          ? (action.allowed_on_statuses.length == 0 ||
+                            action.allowed_on_statuses.indexOf(
                                 currentStatus.value!
-                            ) !== -1
+                            ) !== -1)
                           : true
                   )
                 : actions.value


### PR DESCRIPTION
Due to chart-ext change of behaivour, a missing `allowed_on_statuses` of action, would become an empty vector:
https://github.com/platzio/chart-ext/commit/296becfbc66eea8b2d2e05195f5bb079d22cb758

This PR ensures that empty vector of `allowed_on_statuses` would act as there is no status required