### PR TITLE
Add 'BROKEN' notification for helm-chart with error

### DIFF
--- a/src/pages/main/env/deployments/DeploymentForm.vue
+++ b/src/pages/main/env/deployments/DeploymentForm.vue
@@ -55,6 +55,7 @@
                 :disabled="!chart.available"
             >
                 {{ chart.available ? "" : "[DELETED]" }}
+                {{ chart.error ? "[BROKEN]" : "" }}
                 {{ chart.image_tag }} (from {{ fromNow(chart.created_at) }})
             </option>
         </select>


### PR DESCRIPTION
There is no indication for helm-chart with errors when choosing version for deployment.