### PR TITLE
Build dist inside Dockerfile (multi-stage, multi-arch)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,7 @@
-src
+.git
+.github
+.vscode
 node_modules
+dist
+LICENSE
+README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,6 @@ jobs:
       - name: 📦 npm run lint
         run: npm run lint
 
-      - name: 📦 npm run build
-        run: npm run build
-
       - name: 🏷 Get tag
         id: tag
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,18 @@
+# syntax=docker/dockerfile:1.7
+
+# Build stage runs on the host architecture (no QEMU emulation)
+# since the output is static assets that are identical across arches.
+FROM --platform=$BUILDPLATFORM node:24-alpine AS build
+WORKDIR /app
+RUN apk add --no-cache git \
+ && git config --global url."https://github.com/".insteadOf "ssh://git@github.com/" \
+ && git config --global url."https://github.com/".insteadOf "git@github.com:"
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
 FROM nginx:1-alpine-slim
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY dist/ /usr/share/nginx/html/
+COPY --from=build /app/dist/ /usr/share/nginx/html/
 CMD ["/usr/sbin/nginx", "-c", "/etc/nginx/nginx.conf"]


### PR DESCRIPTION
## Summary

Make `docker build .` self-contained — the previous Dockerfile copied a
pre-built `dist/` from the host, so the image only existed as a side
effect of the CI workflow and couldn't be reproduced locally.

### Dockerfile

Multi-stage build with a Node 24 alpine build stage and the existing
nginx alpine runtime stage. The build stage is pinned to
`--platform=$BUILDPLATFORM` so buildx runs it once on the runner's
native architecture instead of under QEMU emulation per target — this
is safe because the output is static assets that are identical across
architectures. Multi-arch is preserved by the final nginx stage being
emitted for each requested target platform (`linux/amd64`,
`linux/arm64`).

The `@platzio/design` git dep resolves to `git+ssh://` in the lockfile,
so the build stage installs git and rewrites GitHub SSH URLs to HTTPS
to avoid needing SSH credentials inside Docker.

### .dockerignore

Now that the build runs inside Docker, the build context needs `src/`
and the config files. Switched the ignore list to exclude noise
(`.git`, `.github`, `.vscode`, `node_modules`, `dist`, `LICENSE`,
`README.md`).

### CI workflow

Removed `npm run build` from the release workflow since the Docker
build now produces `dist/` itself. `npm run lint` is kept as a fast
pre-check before the (slower) multi-arch image build, so lint failures
fail-fast.

## Test plan

- [x] `npm ci && npm run build` in a clean checkout (with the git
  SSH→HTTPS rewrite applied) succeeds — same dist as before
- [ ] `docker buildx build --platform linux/amd64,linux/arm64 .`
  produces a working image (couldn't run locally — no Docker daemon in
  the sandbox)
- [ ] Release workflow on a tag push builds + pushes a multi-arch image
  to DockerHub

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUAxbFvsAUxWp6GbJqixWo)_