### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🛠️ Setup node
         uses: actions/setup-node@v4
@@ -34,16 +34,16 @@ jobs:
           echo "tag=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
       - name: 🐳 Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: 🛠️ Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🐳 Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
Normalize GitHub Actions to the versions used across the other Platzio repos:

- `actions/checkout` v4 → v6
- `docker/build-push-action` v6 → v7
- `docker/login-action` v3 → v4
- `docker/setup-buildx-action` v3 → v4

npm dependencies are already current within their ranges (`npm outdated` is clean), so no `package.json` changes. Part of the pre-release dependency refresh ahead of the next beta.

https://claude.ai/code/session_012x3qrx2pZ4HtbhJPB6W5Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_012x3qrx2pZ4HtbhJPB6W5Zv)_