### PR TITLE
Authenticate the events websocket via subprotocol

### DIFF
--- a/src/store/ws.ts
+++ b/src/store/ws.ts
@@ -2,6 +2,14 @@ import { computed, reactive } from "vue";
 import { createCollections } from "./collections";
 import { type DbEvent } from "@platzio/sdk";
 
+// Subprotocol used to carry the access token to the backend websocket. Browsers
+// cannot set an Authorization header on a WebSocket, so the token is passed as a
+// subprotocol value, which the browser sends in the Sec-WebSocket-Protocol
+// header. Must match WS_AUTH_PROTOCOL on the backend.
+const WS_AUTH_PROTOCOL = "platz-auth-bearer";
+
+const ACCESS_TOKEN_ITEM = "access_token";
+
 export function startWsUpdates({
   dbTableToCollection,
 }: ReturnType<typeof createCollections>) {
@@ -30,12 +38,21 @@ export function startWsUpdates({
       return;
     }
 
+    const accessToken = localStorage.getItem(ACCESS_TOKEN_ITEM);
+    if (!accessToken) {
+      // Without a token the backend rejects the connection. Wait for auth to
+      // populate the token; index.ts (re)starts updates once auth is ready.
+      state.status = "not authenticated";
+      return;
+    }
+
     state.started = true;
     state.status = undefined;
     const socket = new WebSocket(
       `${location.protocol === "https:" ? "wss" : "ws"}://${
         location.host
-      }/api/v2/ws`
+      }/api/v2/ws`,
+      [WS_AUTH_PROTOCOL, accessToken]
     );
 
     socket.onopen = () => {


### PR DESCRIPTION
## Summary

The events websocket on the backend now **requires authentication** and rejects anonymous connections (part of the websocket scalability/security work). Browsers cannot set an `Authorization` header on a `WebSocket`, so this passes the access token as a `Sec-WebSocket-Protocol` value.

- Connect with `new WebSocket(url, [WS_AUTH_PROTOCOL, accessToken])`, where `WS_AUTH_PROTOCOL = "platz-auth-bearer"` matches the backend.
- Read the token from `localStorage` (`access_token`) at connect time, so reconnects pick up a refreshed token.
- Skip connecting entirely when no token is present (the store restarts updates once auth is ready), avoiding a 401/reconnect loop.

## Dependency

Requires the matching backend change (branch `claude/platz-websocket-scalability-8o33vx` on `platzio/backend`), which adds websocket authentication, per-environment event filtering, and SQL-level permission scoping on the REST endpoints. This frontend change should land together with — or after — the backend one; against an old backend the connection still works (the subprotocol is simply ignored).

## Testing

- `npm run type-check` (vue-tsc) passes.

https://claude.ai/code/session_019WuF56UqDxdJkYmk4zXD88

---
_Generated by [Claude Code](https://claude.ai/code/session_019WuF56UqDxdJkYmk4zXD88)_